### PR TITLE
Hide references to WWW behind a precompiler flag

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/CoroutineAsyncBridge.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/CoroutineAsyncBridge.cs
@@ -86,10 +86,12 @@ namespace UniRx
 
     public static class CoroutineAsyncExtensions
     {
+#if !UNITY_2018_2_OR_NEWER
         public static CoroutineAsyncBridge<WWW> GetAwaiter(this WWW www)
         {
             return CoroutineAsyncBridge<WWW>.Start(www);
         }
+#endif
 
         public static CoroutineAsyncBridge GetAwaiter(this Coroutine coroutine)
         {

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/MainThreadDispatcher.cs
@@ -117,13 +117,15 @@ namespace UniRx
                     }
 
                     var type = current.GetType();
+#if !UNITY_2018_2_OR_NEWER
                     if (type == typeof(WWW))
                     {
                         var www = (WWW)current;
                         editorQueueWorker.Enqueue(_ => ConsumeEnumerator(UnwrapWaitWWW(www, routine)), null);
                         return;
                     }
-                    else if (type == typeof(AsyncOperation))
+#endif
+                    if (type == typeof(AsyncOperation))
                     {
                         var asyncOperation = (AsyncOperation)current;
                         editorQueueWorker.Enqueue(_ => ConsumeEnumerator(UnwrapWaitAsyncOperation(asyncOperation, routine)), null);
@@ -156,6 +158,7 @@ namespace UniRx
                 }
             }
 
+#if !UNITY_2018_2_OR_NEWER
             IEnumerator UnwrapWaitWWW(WWW www, IEnumerator continuation)
             {
                 while (!www.isDone)
@@ -164,6 +167,7 @@ namespace UniRx
                 }
                 ConsumeEnumerator(continuation);
             }
+#endif
 
             IEnumerator UnwrapWaitAsyncOperation(AsyncOperation asyncOperation, IEnumerator continuation)
             {

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Observable.Unity.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/Observable.Unity.cs
@@ -233,7 +233,9 @@ namespace UniRx
     {
         readonly static HashSet<Type> YieldInstructionTypes = new HashSet<Type>
         {
+#if !UNITY_2018_2_OR_NEWER
             typeof(WWW),
+#endif
             typeof(WaitForEndOfFrame),
             typeof(WaitForFixedUpdate),
             typeof(WaitForSeconds),

--- a/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ObservableWWW.cs
+++ b/Assets/Plugins/UniRx/Scripts/UnityEngineBridge/ObservableWWW.cs
@@ -1,3 +1,4 @@
+#if !UNITY_2018_2_OR_NEWER
 using System;
 using System.Collections;
 using UnityEngine;
@@ -433,3 +434,4 @@ namespace UniRx
         }
     }
 }
+#endif


### PR DESCRIPTION
@sbergen Should I use `UNITY_2018_2_OR_NEWER` or some other flag?