### PR TITLE
Fix most classes using ListObserver<T>

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/Subjects/AsyncSubject.cs
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/AsyncSubject.cs
@@ -1,257 +1,408 @@
-﻿using System;
-using System.Collections.Generic;
-using UniRx.InternalUtil;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE_DOTNET file in the project root for more information.
 
-#if (NET_4_6 || NET_STANDARD_2_0)
+// Changes:
+// * use UniRx namespace
+// * use default(T) instead of default
+// * Use ?.Throw() instead of ThrowIfNotNull
+// * Inline Strings_Linq.NO_ELEMENTS
+// * Add Value property
+
+using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
-#endif
+using UniRx.InternalUtil;
 
 namespace UniRx
 {
-    public sealed class AsyncSubject<T> : ISubject<T>, IOptimizedObservable<T>, IDisposable
-#if (NET_4_6 || NET_STANDARD_2_0)
-        , INotifyCompletion
-#endif
+    /// <summary>
+    /// Represents the result of an asynchronous operation.
+    /// The last value before the OnCompleted notification, or the error received through OnError, is sent to all subscribed observers.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements processed by the subject.</typeparam>
+    public sealed class AsyncSubject<T> : SubjectBase<T>, INotifyCompletion
     {
-        object observerLock = new object();
+        #region Fields
 
-        T lastValue;
-        bool hasValue;
-        bool isStopped;
-        bool isDisposed;
-        Exception lastError;
-        IObserver<T> outObserver = EmptyObserver<T>.Instance;
+        private AsyncSubjectDisposable[] _observers;
+        private T _value;
+        private bool _hasValue;
+        private Exception _exception;
+
+        /// <summary>
+        /// A pre-allocated empty array indicating the AsyncSubject has terminated
+        /// </summary>
+        private static readonly AsyncSubjectDisposable[] Terminated = new AsyncSubjectDisposable[0];
+
+        /// <summary>
+        /// A pre-allocated empty array indicating the AsyncSubject has terminated
+        /// </summary>
+        private static readonly AsyncSubjectDisposable[] Disposed = new AsyncSubjectDisposable[0];
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a subject that can only receive one value and that value is cached for all future observations.
+        /// </summary>
+        public AsyncSubject()
+        {
+            _observers = Array.Empty<AsyncSubjectDisposable>();
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Indicates whether the subject has observers subscribed to it.
+        /// </summary>
+        public override bool HasObservers => _observers.Length != 0;
+
+        /// <summary>
+        /// Indicates whether the subject has been disposed.
+        /// </summary>
+        public override bool IsDisposed => Volatile.Read(ref _observers) == Disposed;
 
         public T Value
         {
-            get
-            {
-                ThrowIfDisposed();
-                if (!isStopped) throw new InvalidOperationException("AsyncSubject is not completed yet");
-                if (lastError != null) lastError.Throw();
-                return lastValue;
-            }
+	        get
+	        {
+		        var observers = Volatile.Read(ref _observers);
+		        if (observers == Disposed)
+		        {
+			        ThrowDisposed();
+		        }
+		        else if (observers != Terminated)
+		        {
+			        throw new InvalidOperationException("AsyncSubject is not completed yet");
+		        }
+
+		        var ex = _exception;
+			    ex?.Throw();
+
+		        return _value;
+	        }
         }
 
-        public bool HasObservers
+        #endregion
+
+        #region Methods
+
+        #region IObserver<T> implementation
+
+        /// <summary>
+        /// Notifies all subscribed observers about the end of the sequence, also causing the last received value to be sent out (if any).
+        /// </summary>
+        public override void OnCompleted()
         {
-            get
+            for (; ; )
             {
-                return !(outObserver is EmptyObserver<T>) && !isStopped && !isDisposed;
-            }
-        }
-
-        public bool IsCompleted { get { return isStopped; } }
-
-        public void OnCompleted()
-        {
-            IObserver<T> old;
-            T v;
-            bool hv;
-            lock (observerLock)
-            {
-                ThrowIfDisposed();
-                if (isStopped) return;
-
-                old = outObserver;
-                outObserver = EmptyObserver<T>.Instance;
-                isStopped = true;
-                v = lastValue;
-                hv = hasValue;
-            }
-
-            if (hv)
-            {
-                old.OnNext(v);
-                old.OnCompleted();
-            }
-            else
-            {
-                old.OnCompleted();
-            }
-        }
-
-        public void OnError(Exception error)
-        {
-            if (error == null) throw new ArgumentNullException("error");
-
-            IObserver<T> old;
-            lock (observerLock)
-            {
-                ThrowIfDisposed();
-                if (isStopped) return;
-
-                old = outObserver;
-                outObserver = EmptyObserver<T>.Instance;
-                isStopped = true;
-                lastError = error;
-            }
-
-            old.OnError(error);
-        }
-
-        public void OnNext(T value)
-        {
-            lock (observerLock)
-            {
-                ThrowIfDisposed();
-                if (isStopped) return;
-
-                this.hasValue = true;
-                this.lastValue = value;
-            }
-        }
-
-        public IDisposable Subscribe(IObserver<T> observer)
-        {
-            if (observer == null) throw new ArgumentNullException("observer");
-
-            var ex = default(Exception);
-            var v = default(T);
-            var hv = false;
-
-            lock (observerLock)
-            {
-                ThrowIfDisposed();
-                if (!isStopped)
+                var observers = Volatile.Read(ref _observers);
+                if (observers == Disposed)
                 {
-                    var listObserver = outObserver as ListObserver<T>;
-                    if (listObserver != null)
+                    _exception = null;
+                    ThrowDisposed();
+                    break;
+                }
+                if (observers == Terminated)
+                {
+                    break;
+                }
+                if (Interlocked.CompareExchange(ref _observers, Terminated, observers) == observers)
+                {
+                    var hasValue = _hasValue;
+                    if (hasValue)
                     {
-                        outObserver = listObserver.Add(observer);
+                        var value = _value;
+
+                        foreach (var o in observers)
+                        {
+                            if (!o.IsDisposed())
+                            {
+                                o.Downstream.OnNext(value);
+                                o.Downstream.OnCompleted();
+                            }
+                        }
                     }
                     else
                     {
-                        var current = outObserver;
-                        if (current is EmptyObserver<T>)
+                        foreach (var o in observers)
                         {
-                            outObserver = observer;
-                        }
-                        else
-                        {
-                            outObserver = new ListObserver<T>(new ImmutableList<IObserver<T>>(new[] { current, observer }));
+                            if (!o.IsDisposed())
+                            {
+                                o.Downstream.OnCompleted();
+                            }
                         }
                     }
+                }
+            }
+        }
 
-                    return new Subscription(this, observer);
+        /// <summary>
+        /// Notifies all subscribed observers about the exception.
+        /// </summary>
+        /// <param name="error">The exception to send to all observers.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="error"/> is <c>null</c>.</exception>
+        public override void OnError(Exception error)
+        {
+            if (error == null)
+            {
+                throw new ArgumentNullException(nameof(error));
+            }
+
+            for (; ; )
+            {
+                var observers = Volatile.Read(ref _observers);
+                if (observers == Disposed)
+                {
+                    _exception = null;
+                    _value = default(T);
+                    ThrowDisposed();
+                    break;
+                }
+                if (observers == Terminated)
+                {
+                    break;
+                }
+                _exception = error;
+                if (Interlocked.CompareExchange(ref _observers, Terminated, observers) == observers)
+                {
+                    foreach (var o in observers)
+                    {
+                        if (!o.IsDisposed())
+                        {
+                            o.Downstream.OnError(error);
+                        }
+                    }
+                }
+            }
+
+        }
+
+        /// <summary>
+        /// Sends a value to the subject. The last value received before successful termination will be sent to all subscribed and future observers.
+        /// </summary>
+        /// <param name="value">The value to store in the subject.</param>
+        public override void OnNext(T value)
+        {
+            var observers = Volatile.Read(ref _observers);
+            if (observers == Disposed)
+            {
+                _value = default(T);
+                _exception = null;
+                ThrowDisposed();
+                return;
+            }
+            if (observers == Terminated)
+            {
+                return;
+            }
+
+            _value = value;
+            _hasValue = true;
+        }
+
+        #endregion
+
+        #region IObservable<T> implementation
+
+        /// <summary>
+        /// Subscribes an observer to the subject.
+        /// </summary>
+        /// <param name="observer">Observer to subscribe to the subject.</param>
+        /// <returns>Disposable object that can be used to unsubscribe the observer from the subject.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="observer"/> is <c>null</c>.</exception>
+        public override IDisposable Subscribe(IObserver<T> observer)
+        {
+            if (observer == null)
+            {
+                throw new ArgumentNullException(nameof(observer));
+            }
+
+            var parent = new AsyncSubjectDisposable(this, observer);
+
+            if (!Add(parent))
+            {
+                var ex = _exception;
+                if (ex != null)
+                {
+                    observer.OnError(ex);
+                }
+                else
+                {
+                    if (_hasValue)
+                    {
+                        observer.OnNext(_value);
+                    }
+                    observer.OnCompleted();
+                }
+                return Disposable.Empty;
+            }
+
+            return parent;
+        }
+
+        private bool Add(AsyncSubjectDisposable inner)
+        {
+            for (; ; )
+            {
+                var a = Volatile.Read(ref _observers);
+                if (a == Disposed)
+                {
+                    _value = default(T);
+                    _exception = null;
+                    ThrowDisposed();
+                    return true;
                 }
 
-                ex = lastError;
-                v = lastValue;
-                hv = hasValue;
-            }
+                if (a == Terminated)
+                {
+                    return false;
+                }
 
-            if (ex != null)
-            {
-                observer.OnError(ex);
-            }
-            else if (hv)
-            {
-                observer.OnNext(v);
-                observer.OnCompleted();
-            }
-            else
-            {
-                observer.OnCompleted();
-            }
-
-            return Disposable.Empty;
-        }
-
-        public void Dispose()
-        {
-            lock (observerLock)
-            {
-                isDisposed = true;
-                outObserver = DisposedObserver<T>.Instance;
-                lastError = null;
-                lastValue = default(T);
+                var n = a.Length;
+                var b = new AsyncSubjectDisposable[n + 1];
+                Array.Copy(a, 0, b, 0, n);
+                b[n] = inner;
+                if (Interlocked.CompareExchange(ref _observers, b, a) == a)
+                {
+                    return true;
+                }
             }
         }
 
-        void ThrowIfDisposed()
+        private void Remove(AsyncSubjectDisposable inner)
         {
-            if (isDisposed) throw new ObjectDisposedException("");
-        }
-
-        public bool IsRequiredSubscribeOnCurrentThread()
-        {
-            return false;
-        }
-
-        class Subscription : IDisposable
-        {
-            readonly object gate = new object();
-            AsyncSubject<T> parent;
-            IObserver<T> unsubscribeTarget;
-
-            public Subscription(AsyncSubject<T> parent, IObserver<T> unsubscribeTarget)
+            for (; ; )
             {
-                this.parent = parent;
-                this.unsubscribeTarget = unsubscribeTarget;
+                var a = Volatile.Read(ref _observers);
+
+                var n = a.Length;
+
+                if (n == 0)
+                {
+                    break;
+                }
+
+                var j = -1;
+
+                for (var i = 0; i < n; i++)
+                {
+                    if (a[i] == inner)
+                    {
+                        j = i;
+                        break;
+                    }
+                }
+
+                if (j < 0)
+                {
+                    break;
+                }
+
+                var b = default(AsyncSubjectDisposable[]);
+                if (n == 1)
+                {
+                    b = Array.Empty<AsyncSubjectDisposable>();
+                }
+                else
+                {
+                    b = new AsyncSubjectDisposable[n - 1];
+                    Array.Copy(a, 0, b, 0, j);
+                    Array.Copy(a, j + 1, b, j, n - j - 1);
+                }
+
+                if (Interlocked.CompareExchange(ref _observers, b, a) == a)
+                {
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// A disposable connecting the AsyncSubject and an IObserver.
+        /// </summary>
+        private sealed class AsyncSubjectDisposable : IDisposable
+        {
+            internal readonly IObserver<T> Downstream;
+            private AsyncSubject<T> _parent;
+
+            public AsyncSubjectDisposable(AsyncSubject<T> parent, IObserver<T> downstream)
+            {
+                _parent = parent;
+                Downstream = downstream;
             }
 
             public void Dispose()
             {
-                lock (gate)
-                {
-                    if (parent != null)
-                    {
-                        lock (parent.observerLock)
-                        {
-                            var listObserver = parent.outObserver as ListObserver<T>;
-                            if (listObserver != null)
-                            {
-                                parent.outObserver = listObserver.Remove(unsubscribeTarget);
-                            }
-                            else
-                            {
-                                parent.outObserver = EmptyObserver<T>.Instance;
-                            }
+                Interlocked.Exchange(ref _parent, null)?.Remove(this);
+            }
 
-                            unsubscribeTarget = null;
-                            parent = null;
-                        }
-                    }
-                }
+            internal bool IsDisposed()
+            {
+                return Volatile.Read(ref _parent) == null;
             }
         }
 
+        #endregion
 
-#if (NET_4_6 || NET_STANDARD_2_0)
+        #region IDisposable implementation
+
+        private void ThrowDisposed()
+        {
+            throw new ObjectDisposedException(string.Empty);
+        }
+
+        /// <summary>
+        /// Unsubscribe all observers and release resources.
+        /// </summary>
+        public override void Dispose()
+        {
+            if (Interlocked.Exchange(ref _observers, Disposed) != Disposed)
+            {
+                _exception = null;
+                _value = default(T);
+                _hasValue = false;
+            }
+        }
+
+        #endregion
+
+        #region Await support
 
         /// <summary>
         /// Gets an awaitable object for the current AsyncSubject.
         /// </summary>
         /// <returns>Object that can be awaited.</returns>
-        public AsyncSubject<T> GetAwaiter()
-        {
-            return this;
-        }
+        public AsyncSubject<T> GetAwaiter() => this;
 
         /// <summary>
         /// Specifies a callback action that will be invoked when the subject completes.
         /// </summary>
         /// <param name="continuation">Callback action that will be invoked when the subject completes.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="continuation"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="continuation"/> is <c>null</c>.</exception>
         public void OnCompleted(Action continuation)
         {
             if (continuation == null)
-                throw new ArgumentNullException("continuation");
+            {
+                throw new ArgumentNullException(nameof(continuation));
+            }
 
-            OnCompleted(continuation, true);
+            OnCompleted(continuation, originalContext: true);
         }
 
-         void OnCompleted(Action continuation, bool originalContext)
+        private void OnCompleted(Action continuation, bool originalContext)
         {
             //
             // [OK] Use of unsafe Subscribe: this type's Subscribe implementation is safe.
             //
-            this.Subscribe/*Unsafe*/(new AwaitObserver(continuation, originalContext));
+            Subscribe/*Unsafe*/(new AwaitObserver(continuation, originalContext));
         }
 
-        class AwaitObserver : IObserver<T>
+        private sealed class AwaitObserver : IObserver<T>
         {
             private readonly SynchronizationContext _context;
             private readonly Action _callback;
@@ -259,24 +410,18 @@ namespace UniRx
             public AwaitObserver(Action callback, bool originalContext)
             {
                 if (originalContext)
+                {
                     _context = SynchronizationContext.Current;
+                }
 
                 _callback = callback;
             }
 
-            public void OnCompleted()
-            {
-                InvokeOnOriginalContext();
-            }
+            public void OnCompleted() => InvokeOnOriginalContext();
 
-            public void OnError(Exception error)
-            {
-                InvokeOnOriginalContext();
-            }
+            public void OnError(Exception error) => InvokeOnOriginalContext();
 
-            public void OnNext(T value)
-            {
-            }
+            public void OnNext(T value) { }
 
             private void InvokeOnOriginalContext()
             {
@@ -299,6 +444,11 @@ namespace UniRx
         }
 
         /// <summary>
+        /// Gets whether the AsyncSubject has completed.
+        /// </summary>
+        public bool IsCompleted => Volatile.Read(ref _observers) == Terminated;
+
+        /// <summary>
         /// Gets the last element of the subject, potentially blocking until the subject completes successfully or exceptionally.
         /// </summary>
         /// <returns>The last element of the subject. Throws an InvalidOperationException if no element was received.</returns>
@@ -306,23 +456,25 @@ namespace UniRx
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Await pattern for C# and VB compilers.")]
         public T GetResult()
         {
-            if (!isStopped)
+            if (Volatile.Read(ref _observers) != Terminated)
             {
-                var e = new ManualResetEvent(false);
-                OnCompleted(() => e.Set(), false);
+                var e = new ManualResetEvent(initialState: false);
+                OnCompleted(() => e.Set(), originalContext: false);
                 e.WaitOne();
             }
 
-            if (lastError != null)
+            _exception?.Throw();
+
+            if (!_hasValue)
             {
-                lastError.Throw();
+                throw new InvalidOperationException("Sequence contains no elements.");
             }
 
-            if (!hasValue)
-                throw new InvalidOperationException("NO_ELEMENTS");
-
-            return lastValue;
+            return _value;
         }
-#endif
+
+        #endregion
+
+        #endregion
     }
 }

--- a/Assets/Plugins/UniRx/Scripts/Subjects/Subject.cs
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/Subject.cs
@@ -1,169 +1,289 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using UniRx.InternalUtil;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE_DOTNET file in the project root for more information.
+
+using System;
+using System.Threading;
 
 namespace UniRx
 {
-    public sealed class Subject<T> : ISubject<T>, IDisposable, IOptimizedObservable<T>
+    /// <summary>
+    /// Represents an object that is both an observable sequence as well as an observer.
+    /// Each notification is broadcasted to all subscribed observers.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements processed by the subject.</typeparam>
+    public sealed class Subject<T> : SubjectBase<T>
     {
-        object observerLock = new object();
+        #region Fields
 
-        bool isStopped;
-        bool isDisposed;
-        Exception lastError;
-        IObserver<T> outObserver = EmptyObserver<T>.Instance;
+        private SubjectDisposable[] _observers;
+        private Exception _exception;
+        private static readonly SubjectDisposable[] Terminated = new SubjectDisposable[0];
+        private static readonly SubjectDisposable[] Disposed = new SubjectDisposable[0];
 
-        public bool HasObservers
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a subject.
+        /// </summary>
+        public Subject()
+        {
+            Volatile.Write(ref _observers, Array.Empty<SubjectDisposable>());
+        }
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Indicates whether the subject has observers subscribed to it.
+        /// </summary>
+        public override bool HasObservers
         {
             get
             {
-                return !(outObserver is EmptyObserver<T>) && !isStopped && !isDisposed;
+                return Volatile.Read(ref _observers).Length != 0;
             }
         }
 
-        public void OnCompleted()
+        /// <summary>
+        /// Indicates whether the subject has been disposed.
+        /// </summary>
+        public override bool IsDisposed => Volatile.Read(ref _observers) == Disposed;
+
+        #endregion
+
+        #region Methods
+
+        #region IObserver<T> implementation
+
+        private void ThrowDisposed()
         {
-            IObserver<T> old;
-            lock (observerLock)
-            {
-                ThrowIfDisposed();
-                if (isStopped) return;
-
-                old = outObserver;
-                outObserver = EmptyObserver<T>.Instance;
-                isStopped = true;
-            }
-
-            old.OnCompleted();
+            throw new ObjectDisposedException(string.Empty);
         }
 
-        public void OnError(Exception error)
+        /// <summary>
+        /// Notifies all subscribed observers about the end of the sequence.
+        /// </summary>
+        public override void OnCompleted()
         {
-            if (error == null) throw new ArgumentNullException("error");
-
-            IObserver<T> old;
-            lock (observerLock)
+            for (; ; )
             {
-                ThrowIfDisposed();
-                if (isStopped) return;
-
-                old = outObserver;
-                outObserver = EmptyObserver<T>.Instance;
-                isStopped = true;
-                lastError = error;
-            }
-
-            old.OnError(error);
-        }
-
-        public void OnNext(T value)
-        {
-            outObserver.OnNext(value);
-        }
-
-        public IDisposable Subscribe(IObserver<T> observer)
-        {
-            if (observer == null) throw new ArgumentNullException("observer");
-
-            var ex = default(Exception);
-
-            lock (observerLock)
-            {
-                ThrowIfDisposed();
-                if (!isStopped)
+                var observers = Volatile.Read(ref _observers);
+                if (observers == Disposed)
                 {
-                    var listObserver = outObserver as ListObserver<T>;
-                    if (listObserver != null)
+                    _exception = null;
+                    ThrowDisposed();
+                    break;
+                }
+                if (observers == Terminated)
+                {
+                    break;
+                }
+                if (Interlocked.CompareExchange(ref _observers, Terminated, observers) == observers)
+                {
+                    foreach (var observer in observers)
                     {
-                        outObserver = listObserver.Add(observer);
+                        observer.Observer?.OnCompleted();
+                    }
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Notifies all subscribed observers about the specified exception.
+        /// </summary>
+        /// <param name="error">The exception to send to all currently subscribed observers.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="error"/> is null.</exception>
+        public override void OnError(Exception error)
+        {
+            if (error == null)
+            {
+                throw new ArgumentNullException(nameof(error));
+            }
+
+            for (; ; )
+            {
+                var observers = Volatile.Read(ref _observers);
+                if (observers == Disposed)
+                {
+                    _exception = null;
+                    ThrowDisposed();
+                    break;
+                }
+                if (observers == Terminated)
+                {
+                    break;
+                }
+                _exception = error;
+                if (Interlocked.CompareExchange(ref _observers, Terminated, observers) == observers)
+                {
+                    foreach (var observer in observers)
+                    {
+                        observer.Observer?.OnError(error);
+                    }
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Notifies all subscribed observers about the arrival of the specified element in the sequence.
+        /// </summary>
+        /// <param name="value">The value to send to all currently subscribed observers.</param>
+        public override void OnNext(T value)
+        {
+            var observers = Volatile.Read(ref _observers);
+            if (observers == Disposed)
+            {
+                _exception = null;
+                ThrowDisposed();
+                return;
+            }
+            foreach (var observer in observers)
+            {
+                observer.Observer?.OnNext(value);
+            }
+        }
+
+        #endregion
+
+        #region IObservable<T> implementation
+
+        /// <summary>
+        /// Subscribes an observer to the subject.
+        /// </summary>
+        /// <param name="observer">Observer to subscribe to the subject.</param>
+        /// <returns>Disposable object that can be used to unsubscribe the observer from the subject.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="observer"/> is null.</exception>
+        public override IDisposable Subscribe(IObserver<T> observer)
+        {
+            if (observer == null)
+            {
+                throw new ArgumentNullException(nameof(observer));
+            }
+
+            var disposable = default(SubjectDisposable);
+            for (; ; )
+            {
+                var observers = Volatile.Read(ref _observers);
+                if (observers == Disposed)
+                {
+                    _exception = null;
+                    ThrowDisposed();
+                    break;
+                }
+                if (observers == Terminated)
+                {
+                    var ex = _exception;
+                    if (ex != null)
+                    {
+                        observer.OnError(ex);
                     }
                     else
                     {
-                        var current = outObserver;
-                        if (current is EmptyObserver<T>)
-                        {
-                            outObserver = observer;
-                        }
-                        else
-                        {
-                            outObserver = new ListObserver<T>(new ImmutableList<IObserver<T>>(new[] { current, observer }));
-                        }
+                        observer.OnCompleted();
                     }
-
-                    return new Subscription(this, observer);
+                    break;
                 }
 
-                ex = lastError;
-            }
+                if (disposable == null)
+                {
+                    disposable = new SubjectDisposable(this, observer);
+                }
 
-            if (ex != null)
-            {
-                observer.OnError(ex);
+                var n = observers.Length;
+                var b = new SubjectDisposable[n + 1];
+                Array.Copy(observers, 0, b, 0, n);
+                b[n] = disposable;
+                if (Interlocked.CompareExchange(ref _observers, b, observers) == observers)
+                {
+                    return disposable;
+                }
             }
-            else
-            {
-                observer.OnCompleted();
-            }
-
             return Disposable.Empty;
         }
 
-        public void Dispose()
+        private void Unsubscribe(SubjectDisposable observer)
         {
-            lock (observerLock)
+            for (; ; )
             {
-                isDisposed = true;
-                outObserver = DisposedObserver<T>.Instance;
+                var a = Volatile.Read(ref _observers);
+                var n = a.Length;
+                if (n == 0)
+                {
+                    break;
+                }
+
+                var j = Array.IndexOf(a, observer);
+
+                if (j < 0)
+                {
+                    break;
+                }
+
+                var b = default(SubjectDisposable[]);
+                if (n == 1)
+                {
+                    b = Array.Empty<SubjectDisposable>();
+                }
+                else
+                {
+                    b = new SubjectDisposable[n - 1];
+                    Array.Copy(a, 0, b, 0, j);
+                    Array.Copy(a, j + 1, b, j, n - j - 1);
+                }
+                if (Interlocked.CompareExchange(ref _observers, b, a) == a)
+                {
+                    break;
+                }
             }
         }
 
-        void ThrowIfDisposed()
+        private sealed class SubjectDisposable : IDisposable
         {
-            if (isDisposed) throw new ObjectDisposedException("");
-        }
+            private Subject<T> _subject;
+            private IObserver<T> _observer;
 
-        public bool IsRequiredSubscribeOnCurrentThread()
-        {
-            return false;
-        }
-
-        class Subscription : IDisposable
-        {
-            readonly object gate = new object();
-            Subject<T> parent;
-            IObserver<T> unsubscribeTarget;
-
-            public Subscription(Subject<T> parent, IObserver<T> unsubscribeTarget)
+            public SubjectDisposable(Subject<T> subject, IObserver<T> observer)
             {
-                this.parent = parent;
-                this.unsubscribeTarget = unsubscribeTarget;
+                _subject = subject;
+                Volatile.Write(ref _observer, observer);
             }
 
             public void Dispose()
             {
-                lock (gate)
+                var observer = Interlocked.Exchange(ref _observer, null);
+                if (observer == null)
                 {
-                    if (parent != null)
-                    {
-                        lock (parent.observerLock)
-                        {
-                            var listObserver = parent.outObserver as ListObserver<T>;
-                            if (listObserver != null)
-                            {
-                                parent.outObserver = listObserver.Remove(unsubscribeTarget);
-                            }
-                            else
-                            {
-                                parent.outObserver = EmptyObserver<T>.Instance;
-                            }
-
-                            unsubscribeTarget = null;
-                            parent = null;
-                        }
-                    }
+                    return;
                 }
+
+                _subject.Unsubscribe(this);
+                _subject = null;
             }
+
+            public IObserver<T> Observer { get { return Volatile.Read(ref _observer); } }
         }
+
+        #endregion
+
+        #region IDisposable implementation
+
+        /// <summary>
+        /// Releases all resources used by the current instance of the <see cref="Subject{T}"/> class and unsubscribes all observers.
+        /// </summary>
+        public override void Dispose()
+        {
+            Interlocked.Exchange(ref _observers, Disposed);
+            _exception = null;
+        }
+
+        #endregion
+
+        #endregion
     }
 }

--- a/Assets/Plugins/UniRx/Scripts/Subjects/Subject.cs
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/Subject.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE_DOTNET file in the project root for more information.
 
+// Changes:
+// * use UniRx namespace
+
 using System;
 using System.Threading;
 

--- a/Assets/Plugins/UniRx/Scripts/Subjects/SubjectBase.cs
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/SubjectBase.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE_DOTNET file in the project root for more information.
+
+using System;
+
+namespace UniRx
+{
+    /// <summary>
+    /// Base class for objects that are both an observable sequence as well as an observer.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements processed by the subject.</typeparam>
+    public abstract class SubjectBase<T> : ISubject<T>, IDisposable
+    {
+        /// <summary>
+        /// Indicates whether the subject has observers subscribed to it.
+        /// </summary>
+        public abstract bool HasObservers { get; }
+
+        /// <summary>
+        /// Indicates whether the subject has been disposed.
+        /// </summary>
+        public abstract bool IsDisposed { get; }
+
+        /// <summary>
+        /// Releases all resources used by the current instance of the subject and unsubscribes all observers.
+        /// </summary>
+        public abstract void Dispose();
+
+        /// <summary>
+        /// Notifies all subscribed observers about the end of the sequence.
+        /// </summary>
+        public abstract void OnCompleted();
+
+        /// <summary>
+        /// Notifies all subscribed observers about the specified exception.
+        /// </summary>
+        /// <param name="error">The exception to send to all currently subscribed observers.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="error"/> is <c>null</c>.</exception>
+        public abstract void OnError(Exception error);
+
+        /// <summary>
+        /// Notifies all subscribed observers about the arrival of the specified element in the sequence.
+        /// </summary>
+        /// <param name="value">The value to send to all currently subscribed observers.</param>
+        public abstract void OnNext(T value);
+
+        /// <summary>
+        /// Subscribes an observer to the subject.
+        /// </summary>
+        /// <param name="observer">Observer to subscribe to the subject.</param>
+        /// <returns>Disposable object that can be used to unsubscribe the observer from the subject.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="observer"/> is <c>null</c>.</exception>
+        public abstract IDisposable Subscribe(IObserver<T> observer);
+    }
+}

--- a/Assets/Plugins/UniRx/Scripts/Subjects/SubjectBase.cs.meta
+++ b/Assets/Plugins/UniRx/Scripts/Subjects/SubjectBase.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c344f9856751481bacf6903f10996cab
+timeCreated: 1552897754

--- a/Assets/Scripts/UnityTests/Rx/SubjectTest.cs
+++ b/Assets/Scripts/UnityTests/Rx/SubjectTest.cs
@@ -483,17 +483,26 @@ namespace UniRx.Tests
             UnsubscribeFromOnNextTest(() => new Subject<int>());
         }
 
+        /*
+         
+        Fails on dotnet Rx also, see https://github.com/dotnet/reactive/issues/875
+         
         [Test]
         public void BehaviorSubject_UnsubscribeFromOnNext()
         {
             UnsubscribeFromOnNextTest(() => new BehaviorSubject<int>(0));
         }
 
+        Difference between schedulers makes using dotnet version too hard.
+        This test will still fail...
+
         [Test]
         public void ReplaySubject_UnsubscribeFromOnNext()
         {
             UnsubscribeFromOnNextTest(() => new ReplaySubject<int>());
         }
+        
+        */
 
         [Test]
         public void AsyncSubject_UnsubscribeFromOnNext()

--- a/Assets/Scripts/UnityTests/Rx/SubjectTest.cs
+++ b/Assets/Scripts/UnityTests/Rx/SubjectTest.cs
@@ -508,12 +508,25 @@ namespace UniRx.Tests
 
             bool receivedValue = false;
             IDisposable subscription = null;
-            subject.Subscribe(_ => subscription.Dispose());
+            subject.Subscribe(_ =>
+            {
+                if (subscription != null)
+                {
+                    // Assume order of calls, even though it is not guaranteed,
+                    // otherwise the test doesn't make sense.
+                    Assume.That(receivedValue, Is.False);
+                    subscription.Dispose();
+                    subscription = null;
+                }
+
+            });
             subscription = subject.Subscribe(_ => receivedValue = true);
 
             receivedValue = false;
             subject.OnNext(0);
             subject.OnCompleted();
+
+            Assume.That(subscription, Is.Null);
             Assert.IsFalse(receivedValue);
         }
     }

--- a/Assets/Scripts/UnityTests/Rx/SubjectTest.cs
+++ b/Assets/Scripts/UnityTests/Rx/SubjectTest.cs
@@ -476,5 +476,45 @@ namespace UniRx.Tests
             subject.Subscribe(x => onNext.Add(x), x => exception.Add(x), () => onCompletedCallCount++);
             onNext.Is(10000, 2, 20);
         }
+
+        [Test]
+        public void Subject_UnsubscribeFromOnNext()
+        {
+            UnsubscribeFromOnNextTest(() => new Subject<int>());
+        }
+
+        [Test]
+        public void BehaviorSubject_UnsubscribeFromOnNext()
+        {
+            UnsubscribeFromOnNextTest(() => new BehaviorSubject<int>(0));
+        }
+
+        [Test]
+        public void ReplaySubject_UnsubscribeFromOnNext()
+        {
+            UnsubscribeFromOnNextTest(() => new ReplaySubject<int>());
+        }
+
+        [Test]
+        public void AsyncSubject_UnsubscribeFromOnNext()
+        {
+            UnsubscribeFromOnNextTest(() => new AsyncSubject<int>());
+        }
+
+        private void UnsubscribeFromOnNextTest<T>(Func<T> constructor)
+            where T : ISubject<int>
+        {
+            var subject = constructor();
+
+            bool receivedValue = false;
+            IDisposable subscription = null;
+            subject.Subscribe(_ => subscription.Dispose());
+            subscription = subject.Subscribe(_ => receivedValue = true);
+
+            receivedValue = false;
+            subject.OnNext(0);
+            subject.OnCompleted();
+            Assert.IsFalse(receivedValue);
+        }
     }
 }

--- a/LICENSE_DOTNET
+++ b/LICENSE_DOTNET
@@ -1,0 +1,14 @@
+Copyright (c) .NET Foundation and Contributors
+All Rights Reserved
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You may
+obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions
+and limitations under the License.


### PR DESCRIPTION
While `ListObserver<T>` itself is not broken, the code that uses it doesn't work if a subscription is disposed while `OnNext` is executing. See the added tests for how this fails.

This PR replaces UniRx implementations with dotnet ones where applicable. Only the tests and comments about changes were written by me.

While all `Subject` types in UniRx are affected
* `BehaviorSubject` is broken in dotnet Rx also (see https://github.com/dotnet/reactive/issues/875)
* `ReplaySubject` in dotnet Rx is very different from UniRx due to the scheduler differences

So, we can trivially only fix `Subject` and `AsyncSubject` for now. Will have to investigate how to fix the remaining two later.

IL2CPP compatibility has not yet been tested, will open app-side PR and test builds from CI shortly.