### PR TITLE
Fix WithLatestFrom

### DIFF
--- a/Assets/Plugins/UniRx/Scripts/Operators/WithLatestFrom.cs
+++ b/Assets/Plugins/UniRx/Scripts/Operators/WithLatestFrom.cs
@@ -39,11 +39,12 @@ namespace UniRx.Operators
 
             public IDisposable Run()
             {
-                var l = parent.left.Subscribe(new LeftObserver(this));
                 var rSubscription = new SingleAssignmentDisposable();
                 rSubscription.Disposable  = parent.right.Subscribe(new RightObserver(this, rSubscription));
 
-                return StableCompositeDisposable.Create(l, rSubscription);
+                var lSubscription = parent.left.Subscribe(new LeftObserver(this));
+
+                return StableCompositeDisposable.Create(lSubscription, rSubscription);
             }
 
             public override void OnNext(TResult value)


### PR DESCRIPTION
If both observables have synchronous values available, WithLatestFrom should publish immediately. Currently it does not.

Official Rx implementation for reference: https://github.com/dotnet/reactive/blob/main/Rx.NET/Source/src/System.Reactive/Linq/Observable/WithLatestFrom.cs#L54-L55